### PR TITLE
Specify dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,18 @@ requires-python = ">= 3.8"
 authors = [
   {name = "Naoki Kanazawa", email = "knzwnao@jp.ibm.com"},
 ]
+dependencies = [
+    "pymatching",
+    "qiskit >= 1.0",
+    "qiskit-experiments >= 0.7",
+    "qiskit-ibm-runtime",
+]
+
+[project.optional-dependencies]
+dev = [
+    "black",
+    "ruff",
+]
 
 [tool.setuptools.packages.find]
 include = ["gem_suite", "gem_suite.*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-qiskit >= 1.0
-qiskit-experiments >= 0.7
-pymatching

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,7 @@ setenv =
   RUST_DEBUG=1
 deps =
   setuptools-rust
-  -r{toxinidir}/requirements.txt
   stestr>=4.1
-  qiskit_ibm_runtime
 commands = stestr run {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
- First commit edits `tox.ini` not to install dependencies explicitly, to make sure CI catches this bug