### PR TITLE
use "GEM Suite" for repository name on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ This library is designed to work with, but not limited only to, IBM Quantum proc
 
 ## Installation
 
-This package can be installed from the downloaded repository using pip as
+This package can be installed with `pip` using the command
 
 ```bash
-cd gem-suite
-pip install .
+pip install gem-suite
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GEM experiment suite
+# GEM Suite
 
 [![License](https://img.shields.io/github/license/Qiskit/qiskit-experiments.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)
 


### PR DESCRIPTION
This is a more concise name for the software package. Example usage in a sentence: "You can install the GEM Suite software package using the command `pip install gem-suite`"