### PR TITLE
In transpile options, set routing = "none"

### DIFF
--- a/gem_suite/experiments.py
+++ b/gem_suite/experiments.py
@@ -83,6 +83,7 @@ class GemExperiment(BaseExperiment):
     def _default_transpile_options(cls) -> Options:
         options = super()._default_transpile_options()
         options.optimization_level = 1
+        options.routing_method = "none"
         return options
 
     @classmethod


### PR DESCRIPTION
I think the optimization level can be left to the default. Routing should not be performed, so we set it  to `"none"`.